### PR TITLE
adds the ability to retrieve tasks by short_code

### DIFF
--- a/lib/onfleet-ruby.rb
+++ b/lib/onfleet-ruby.rb
@@ -18,6 +18,7 @@ require 'onfleet-ruby/actions/find'
 require 'onfleet-ruby/actions/save'
 require 'onfleet-ruby/actions/update'
 require 'onfleet-ruby/actions/get'
+require 'onfleet-ruby/actions/short_get'
 require 'onfleet-ruby/actions/list'
 require 'onfleet-ruby/actions/delete'
 require 'onfleet-ruby/actions/query_metadata'
@@ -99,4 +100,3 @@ module Onfleet
     end
   end
 end
-

--- a/lib/onfleet-ruby/actions/short_get.rb
+++ b/lib/onfleet-ruby/actions/short_get.rb
@@ -1,0 +1,17 @@
+module Onfleet
+  module Actions
+    module ShortGet
+      module ClassMethods
+        def short_get(id)
+          api_url = "#{self.api_url}/short/#{id}"
+          response = Onfleet.request(api_url, :get)
+          Util.constantize(name).new(response)
+        end
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+    end
+  end
+end

--- a/lib/onfleet-ruby/task.rb
+++ b/lib/onfleet-ruby/task.rb
@@ -4,6 +4,7 @@ module Onfleet
     include Onfleet::Actions::Save
     include Onfleet::Actions::Update
     include Onfleet::Actions::Get
+    include Onfleet::Actions::ShortGet
     include Onfleet::Actions::List
     include Onfleet::Actions::Delete
     include Onfleet::Actions::QueryMetadata
@@ -21,4 +22,3 @@ module Onfleet
     end
   end
 end
-

--- a/spec/onfleet/task_spec.rb
+++ b/spec/onfleet/task_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe Onfleet::Task do
     it_should_behave_like Onfleet::Actions::Get, path: 'tasks/a-task'
   end
 
+  describe ".short_get" do
+    subject { -> { described_class.short_get(id) } }
+    let(:id) { 'a-task' }
+    it_should_behave_like(
+      Onfleet::Actions::ShortGet,
+      path: 'tasks/short/a-task'
+    )
+  end
+
   describe ".update" do
     subject { -> { described_class.update(id, params) } }
     let(:id) { 'a-task' }
@@ -120,4 +129,3 @@ RSpec.describe Onfleet::Task do
     end
   end
 end
-

--- a/spec/support/http_requests/shared_examples.rb
+++ b/spec/support/http_requests/shared_examples.rb
@@ -46,6 +46,12 @@ RSpec.shared_examples_for Onfleet::Actions::Get do |path:|
   it_should_behave_like "an action that makes a request to Onfleet", method: :get
 end
 
+RSpec.shared_examples_for Onfleet::Actions::ShortGet do |path:|
+  set_up_request_stub(:get, path)
+  let(:response_body) { { id: 'an-object' } }
+  it_should_behave_like "an action that makes a request to Onfleet", method: :get
+end
+
 RSpec.shared_examples_for Onfleet::Actions::List do |path:|
   set_up_request_stub(:get, path)
   let(:response_body) { [{ id: 'an-object' }, { id: 'another-object' }] }
@@ -123,4 +129,3 @@ def camelize_keys(hash)
     accumulator.merge(key.camelize(:lower) => value)
   end
 end
-


### PR DESCRIPTION
Note: this works _just_ like a normal get; but, with a different, more human-readable value that is used throughout the Onfleet UI and its exports.

See for _why_: https://github.com/powersupplyhq/Territory/issues/3989