### PR TITLE
adds support for inconsistently camelized params

### DIFF
--- a/lib/onfleet-ruby/util.rb
+++ b/lib/onfleet-ruby/util.rb
@@ -2,7 +2,11 @@ require 'active_support/core_ext/string/inflections'
 
 module Onfleet
   class Util
-    SPECIAL_PARSE = { 'skip_sms_notifications' => 'skipSMSNotifications' }.freeze
+    SPECIAL_PARSE = {
+      'skip_sms_notifications' => 'skipSMSNotifications',
+      'skip_phone_number_validation' => 'skipPhoneNumberValidation',
+      'recipient_skip_sms_notifications' => 'recipientSkipSMSNotifications'
+    }.freeze
 
     def self.constantize(class_name)
       Object.const_get(class_name)
@@ -34,4 +38,3 @@ module Onfleet
     end
   end
 end
-

--- a/spec/onfleet/recipient_spec.rb
+++ b/spec/onfleet/recipient_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe Onfleet::Recipient do
         ).to have_been_made.once
       end
     end
+
+    context "with the `skip_phone_number_validation` attribute" do
+      set_up_request_stub(:post, 'recipients')
+      let(:params) { { skip_phone_number_validation: true } }
+      let(:response_body) { { id: 'an-object' } }
+
+      it "should camelize the attribute name properly" do
+        subject.call
+        expect(
+          a_request(:post, url).with(
+            body: { 'skipPhoneNumberValidation' => true }.to_json
+          )
+        ).to have_been_made.once
+      end
+    end
   end
 
   describe ".get" do
@@ -72,4 +87,3 @@ RSpec.describe Onfleet::Recipient do
     end
   end
 end
-

--- a/spec/onfleet/task_spec.rb
+++ b/spec/onfleet/task_spec.rb
@@ -31,10 +31,11 @@ RSpec.describe Onfleet::Task do
       let(:response_body) { { id: 'an-object' } }
 
       it "should camelize the attribute name properly" do
-        pending('The SMS acronym does not camelize consistently')
         subject.call
         expect(
-          a_request(:post, url).with(body: { recipientSkipSMSNotifications: true }.to_json)
+          a_request(:post, url).with(
+            body: { recipientSkipSMSNotifications: true }.to_json
+          )
         ).to have_been_made.once
       end
     end
@@ -80,10 +81,14 @@ RSpec.describe Onfleet::Task do
       let(:response_body) { { id: 'an-object' } }
 
       it "should camelize the attribute name properly" do
-        pending('The SMS acronym does not camelize consistently')
         subject.call
         expect(
-          a_request(:put, url).with(body: { recipientSkipSMSNotifications: true }.to_json)
+          a_request(:put, url).with(
+            body: {
+              id: params[:id],
+              recipientSkipSMSNotifications: true
+            }.to_json
+          )
         ).to have_been_made.once
       end
     end


### PR DESCRIPTION
These parameter values are atypically camelized so they need to be parsed separately